### PR TITLE
fix: remove postinstall script

### DIFF
--- a/.changeset/fuzzy-coins-rhyme.md
+++ b/.changeset/fuzzy-coins-rhyme.md
@@ -2,4 +2,4 @@
 '@commercetools/express-request-correlator': patch
 ---
 
-fix(deps): move preconstruct to dependencies
+fix(build): remove postinstall script

--- a/.changeset/fuzzy-coins-rhyme.md
+++ b/.changeset/fuzzy-coins-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@commercetools/express-request-correlator': patch
+---
+
+fix(deps): move preconstruct to dependencies

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@commitlint/cli": "13.2.1",
     "@commitlint/config-conventional": "13.2.0",
     "@manypkg/cli": "0.18.0",
-    "@preconstruct/cli": "2.1.5",
     "@types/jest": "^26.0.20",
     "@types/node": "16.4.13",
     "babel-jest": "27.2.5",
@@ -63,6 +62,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@babel/runtime-corejs3": "^7.13.10",
+    "@preconstruct/cli": "2.1.5",
     "@types/express": "4.17.13",
     "@types/uuid": "8.3.1",
     "uuid": "8.3.2"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Express middleware to help tracing correlation IDs",
   "scripts": {
     "prepare": "husky install",
-    "postinstall": "preconstruct dev",
     "build": "preconstruct build",
     "watch": "preconstruct watch",
     "clean": "manypkg exec rm -rf build dist",
@@ -42,6 +41,7 @@
     "@commitlint/cli": "13.2.1",
     "@commitlint/config-conventional": "13.2.0",
     "@manypkg/cli": "0.18.0",
+    "@preconstruct/cli": "2.1.5",
     "@types/jest": "^26.0.20",
     "@types/node": "16.4.13",
     "babel-jest": "27.2.5",
@@ -62,7 +62,6 @@
   "dependencies": {
     "@babel/runtime": "^7.13.10",
     "@babel/runtime-corejs3": "^7.13.10",
-    "@preconstruct/cli": "2.1.5",
     "@types/express": "4.17.13",
     "@types/uuid": "8.3.1",
     "uuid": "8.3.2"


### PR DESCRIPTION
postinstall script of `preconstruct dev` is not required for standalone repositories.
